### PR TITLE
Implement more save options

### DIFF
--- a/aas_timeseries/data.py
+++ b/aas_timeseries/data.py
@@ -12,18 +12,13 @@ class Data:
         self.uuid = str(uuid.uuid4())
         self.time_column = 'time'
 
-    def to_vega(self):
+    def to_vega(self, embed_data=True):
 
         table = Table()
         table[self.time_column] = self.time_series.time.isot
         for colname in self.time_series.colnames:
             if colname != 'time':
                 table[colname] = self.time_series[colname]
-
-        s = StringIO()
-        table.write(s, format='ascii.basic', delimiter=',')
-        s.seek(0)
-        csv_string = s.read()
 
         parse = {}
         for colname in table.colnames:
@@ -38,8 +33,18 @@ class Data:
                 parse[colname] = 'string'
 
         vega = {'name': self.uuid,
-                'values': csv_string,
                 'format': {'type': 'csv',
                            'parse': parse}}
+
+        if embed_data:
+            s = StringIO()
+            table.write(s, format='ascii.basic', delimiter=',')
+            s.seek(0)
+            csv_string = s.read()
+            vega['values'] = csv_string
+        else:
+            filename = self.uuid + '.csv'
+            table.write(filename, format='ascii.basic', delimiter=',')
+            vega['url'] = filename
 
         return vega

--- a/aas_timeseries/screenshot/screenshot.py
+++ b/aas_timeseries/screenshot/screenshot.py
@@ -22,7 +22,7 @@ def interactive_screenshot(json_filename, png_filename):
 
     tmpdir = tempfile.mkdtemp()
     tmp_html = os.path.join(tmpdir, 'page.html')
-    tmp_json = os.path.join(tmpdir, 'data.json')
+    tmp_json = os.path.join(tmpdir, 'figure.json')
 
     shutil.copy(os.path.join(ROOT, 'template.html'), tmp_html)
     shutil.copy(json_filename, tmp_json)

--- a/aas_timeseries/screenshot/template.html
+++ b/aas_timeseries/screenshot/template.html
@@ -1,46 +1,46 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta charset='utf-8' />
-	<meta http-equiv="X-UA-Compatible" content="chrome=1" />
-	<title>Test</title>
-	<link rel="stylesheet" href="https://aperiosoftware.github.io/timeseries.js/resources/aas.css">
-	<link rel="stylesheet" href="https://aperiosoftware.github.io/timeseries.js/resources/style.css">
-	<link rel="stylesheet" href="https://aperiosoftware.github.io/timeseries.js/resources/timeseries.css">
-	<script language="javascript" type="text/javascript" src="https://aperiosoftware.github.io/timeseries.js/resources/stuquery.js"></script>
-	<script language="javascript" type="text/javascript" src="https://aperiosoftware.github.io/timeseries.js/resources/graph.js"></script>
-	<script language="javascript" type="text/javascript" src="https://aperiosoftware.github.io/timeseries.js/resources/timeseries.js"></script>
 
-	<style type="text/css">
-	body {
-	    overflow:hidden;
-	}
-	</style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset='utf-8' />
+  <meta http-equiv="X-UA-Compatible" content="chrome=1" />
+  <title>Interactive time series</title>
+
+  <link rel="stylesheet" href="https://aperiosoftware.github.io/timeseries.js/resources/aas.css">
+  <link rel="stylesheet" href="https://aperiosoftware.github.io/timeseries.js/resources/style.css">
+  <link rel="stylesheet" href="https://aperiosoftware.github.io/timeseries.js/resources/timeseries.css">
+  <script language="javascript" type="text/javascript" src="https://aperiosoftware.github.io/timeseries.js/resources/stuquery.js"></script>
+  <script language="javascript" type="text/javascript" src="https://aperiosoftware.github.io/timeseries.js/resources/graph.js"></script>
+  <script language="javascript" type="text/javascript" src="https://aperiosoftware.github.io/timeseries.js/resources/timeseries.js"></script>
+
+  <style type="text/css">
+  body {
+      overflow:hidden;
+  }
+  </style>
 </head>
 <body>
 
-	<div class="msg"></div>
+  <div class="msg"></div>
 
-	<!-- MAIN CONTENT -->
-	<div class="row">
-		<div class="example">
-			<figure>
-				<div id="example1">
-				</div>
-			</figure>
-			<!-- Javascript -->
-			<script>
-			var ex1;
-			S(document).ready(function(){
+  <div class="row">
+    <div class="example">
+      <figure>
+        <div id="example1">
+        </div>
+      </figure>
 
-				ex1 = TimeSeries.create("data.json");
-				ex1.initialize(document.getElementById('example1'));
+      <script>
+      var ex1;
+      S(document).ready(function(){
+        ex1 = TimeSeries.create("figure.json");
+        ex1.initialize(document.getElementById('example1'));
+      });
+      </script>
 
-			});
-			</script>
-		</div>
-	</div>
+    </div>
+  </div>
 
 
 </body>

--- a/aas_timeseries/tests/test_visualization.py
+++ b/aas_timeseries/tests/test_visualization.py
@@ -28,6 +28,20 @@ def test_basic(tmpdir):
     figure.save_interactive(filename)
 
 
+def test_save_options(tmpdir):
+
+    ts = TimeSeries(time='2016-03-22T12:30:31', time_delta=3 * u.s, n_samples=5)
+    ts['flux'] = [1, 2, 3, 4, 5]
+    ts['error'] = [1, 2, 3, 4, 5]
+
+    filename = tmpdir.join('figure.json').strpath
+
+    figure = InteractiveTimeSeriesFigure()
+    figure.add_markers(time_series=ts, column='flux', label='Markers')
+    figure.save_interactive(filename, embed_data=True)
+    figure.save_interactive(filename, zip_bundle=True)
+
+
 def test_column_validation():
 
     # Test the validation provied by ColumnTrait

--- a/aas_timeseries/visualization.py
+++ b/aas_timeseries/visualization.py
@@ -59,7 +59,7 @@ class InteractiveTimeSeriesFigure(BaseView):
 
         return view
 
-    def save_interactive(self, filename, override_style=False):
+    def save_interactive(self, filename, override_style=False, embed_data=True):
         """
         Save a Vega-compatible JSON file that contains the specification for
         the interactive figure.
@@ -72,6 +72,9 @@ class InteractiveTimeSeriesFigure(BaseView):
             By default, any unspecified colors will be automatically chosen.
             If this parameter is set to `True`, all colors will be reassigned,
             even if already set.
+        embed_data : bool, optional
+            Whether to embed the data in the JSON file (`True`) or include it
+            in separate CSV files (`False`).
         """
 
         colors = auto_assign_colors(self._layers)
@@ -80,7 +83,7 @@ class InteractiveTimeSeriesFigure(BaseView):
                 layer.color = color
 
         with open(filename, 'w') as f:
-            dump(self._to_json(), f, indent='  ')
+            dump(self._to_json(embed_data=embed_data), f, indent='  ')
 
     def preview_interactive(self):
         """
@@ -89,11 +92,11 @@ class InteractiveTimeSeriesFigure(BaseView):
         """
         # FIXME: should be able to do without a file
         tmpfile = tempfile.mktemp()
-        self.save_interactive(tmpfile)
+        self.save_interactive(tmpfile, embed_data=True)
         widget = TimeSeriesWidget(tmpfile)
         return widget
 
-    def _to_json(self):
+    def _to_json(self, embed_data=True):
 
         # Start off with empty JSON
         json = {}
@@ -108,7 +111,7 @@ class InteractiveTimeSeriesFigure(BaseView):
         json['autosize'] = {'type': 'fit', 'resize': self._resize}
 
         # Data
-        json['data'] = [data.to_vega() for data in self._data.values()]
+        json['data'] = [data.to_vega(embed_data=embed_data) for data in self._data.values()]
         json['marks'] = []
         for layer, settings in self._layers.items():
             json['marks'].extend(layer.to_vega())

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,5 +29,6 @@ User guide
    getting_started
    layers
    views
+   saving.rst
    submitting.rst
    api.rst

--- a/docs/saving.rst
+++ b/docs/saving.rst
@@ -1,0 +1,17 @@
+Saving the interactive figure
+=============================
+
+To save the interactive figure to `Vega <https://vega.github.io/vega/>`_-
+compliant JSON, use::
+
+    fig.save_interactive('my_figure.json')
+
+By default, the data will be saved to separate CSV files, but you can also force
+the data to be embedded inside the JSON file by using::
+
+    fig.save_interactive('my_figure.json', embed_data=True)
+
+Finally, you can also save the JSON file and data files along with a template
+HTML file to view your interactive figure to a zip file by using::
+
+    fig.save_interactive('my_figure.zip', zip_bundle=True)

--- a/docs/submitting.rst
+++ b/docs/submitting.rst
@@ -5,9 +5,9 @@ Submitting an interactive figure to AAS Journals
              produced here are not yet ready to be submitted to AAS Journals.
 
 To include an interactive figure in your paper, first make sure you export
-the interactive figure(s) you have produced to a JSON file::
+the interactive figure(s) you have produced to a zip file::
 
-    fig.save_interactive('my_figure.json')
+    fig.save_interactive('my_figure.zip', zip_bundle=True)
 
 The workflow to include your figure in the paper will be added here in the near
 future.


### PR DESCRIPTION
This adds two options to ``save_interactive``:

* ``embed_data=True/False`` for controlling whether the data is included in the JSON or distributed separately as a CSV file. Fixes https://github.com/aperiosoftware/aas-timeseries/issues/20.

* ``zip_bundle=True/False`` for controlling whether to create a zip file with the required HTML, JSON, and CSV files.