### PR TITLE
setup.cfg: install screenshot/template.html as package_data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,9 @@ test =
   faker
 
 [options.package_data]
-aas_timeseries = **/data/**/*
+aas_timeseries =
+  **/data/**/*
+  screenshot/template.html
 aas_timeseries.tests = coveragerc
 
 [bdist_wheel]


### PR DESCRIPTION
Otherwise, `export_interactive_bundle()` doesn't work when the package has been installed via pip.

... which is a pretty significant issue! A new release is probably warranted with the impending launch.